### PR TITLE
fix cargo fmt errors; update test modules

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -179,26 +179,20 @@ impl Rkv {
 
 #[cfg(test)]
 mod tests {
-    extern crate byteorder;
-    extern crate tempfile;
-
-    use self::byteorder::{
+    use byteorder::{
         ByteOrder,
         LittleEndian,
     };
-
-    use self::tempfile::Builder;
-
     use std::{
         fs,
         str,
+        sync::{
+            Arc,
+            RwLock,
+        },
         thread,
     };
-
-    use std::sync::{
-        Arc,
-        RwLock,
-    };
+    use tempfile::Builder;
 
     use super::*;
     use crate::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,8 @@
 use std::path::PathBuf;
 
 use bincode;
-use lmdb;
 use failure::Fail;
+use lmdb;
 
 use crate::value::Type;
 

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -144,10 +144,8 @@ impl IntegerStore {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-
-    use self::tempfile::Builder;
     use std::fs;
+    use tempfile::Builder;
 
     use super::*;
     use crate::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,6 @@
 //!
 //! ## Basic Usage
 //! ```
-//! extern crate rkv;
-//! extern crate tempfile;
-//!
 //! use rkv::{Manager, Rkv, Store, Value};
 //! use std::fs;
 //! use tempfile::Builder;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -122,10 +122,8 @@ impl Manager {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-
-    use self::tempfile::Builder;
     use std::fs;
+    use tempfile::Builder;
 
     use super::*;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,12 +8,12 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use ordered_float::OrderedFloat;
 use arrayref::array_ref;
 use bincode::{
     deserialize,
     serialize,
 };
+use ordered_float::OrderedFloat;
 
 use uuid::{
     Bytes,

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -8,22 +8,14 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-extern crate bincode;
-extern crate rkv;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate tempfile;
-
 use rkv::{
     PrimitiveInt,
     Rkv,
     Value,
 };
-
-use self::tempfile::Builder;
-
+use serde_derive::Serialize;
 use std::fs;
+use tempfile::Builder;
 
 #[test]
 fn test_integer_keys() {

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -8,19 +8,15 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-extern crate rkv;
-extern crate tempfile;
-
 use rkv::{
     Manager,
     Rkv,
 };
-
-use self::tempfile::Builder;
-
-use std::fs;
-
-use std::sync::Arc;
+use std::{
+    fs,
+    sync::Arc,
+};
+use tempfile::Builder;
 
 #[test]
 // Identical to the same-named unit test, but this one confirms that it works


### PR DESCRIPTION
@rrichardson Automated tests reported some `cargo fmt` errors. In the process of fixing those, I noticed that test modules were still using `extern crate` declarations, so I updated those as well.